### PR TITLE
Implement custom partitioning key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,97 +23,102 @@ usage: prometheus-pulsar-remote-write [<flags>]
 Pulsar Remote storage adapter for Prometheus
 
 Flags:
-  -h, --help                    Show context-sensitive help (also try
-                                --help-long and --help-man).
-      --send-timeout=30s        The timeout to use when sending samples to the
-                                remote storage.
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
+      --send-timeout=30s         The timeout to use when sending samples to the
+                                 remote storage.
       --web.listen-address=":9201"  
-                                Address to listen on for web endpoints.
+                                 Address to listen on for web endpoints.
       --web.telemetry-path="/metrics"  
-                                Address to listen on for web endpoints.
-      --pulsar.url=""           The URL of the remote Pulsar server to send
-                                samples to. Example: pulsar://pulsar-proxy:6650.
-                                None, if empty.
+                                 Path under which to expose metrics.
+      --web.write-path="/write"  Path under which to receive remote_write
+                                 requests.
+      --replica-label=__replica__ ...  
+                                 External label to identify replicas. Can be
+                                 specified multiple times.
+      --pulsar.url=""            The URL of the remote Pulsar server to send
+                                 samples to. Example:
+                                 pulsar://pulsar-proxy:6650. None, if empty.
       --pulsar.connection-timeout=30s  
-                                The timeout to use when connection to the remote
-                                Pulsar server.
+                                 The timeout to use when connection to the
+                                 remote Pulsar server.
       --pulsar.serializer="json"  
-                                Specifies the serialization format
-                                
-                                json: JSON default format as defined by
-                                github.com/prometheus/common/model
-                                
-                                {
-                                
-                                  "metric": {
-                                    "__name__": "foo",
-                                    "labelfoo": "label-bar"
-                                  },
-                                  "value": [
-                                    0,
-                                    "456"
-                                  ]
-                                
-                                }
-                                
-                                json-compat: JSON compat provides compatability
-                                with
-                                github.com/liangyuanpeng/prometheus-pulsar-adapter
-                                
-                                {
-                                
-                                  "name": "foo",
-                                  "labels": {
-                                    "__name__": "foo",
-                                    "labelfoo": "label-bar"
-                                  },
-                                  "value": "456",
-                                  "timestamp": "1970-01-01T00:00:00Z"
-                                
-                                }
-                                
-                                avro-json-compat[=<path to schema>]: AVRO-JSON
-                                which can optionally read a custom schema
-                                
-                                Default schema: {
-                                
-                                  "namespace": "io.prometheus",
-                                  "type": "record",
-                                  "name": "Metric",
-                                  "doc:": "A basic schema for representing Prometheus metrics",
-                                  "fields": [
-                                    {
-                                      "name": "timestamp",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "name": "value",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "name": "name",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "name": "labels",
-                                      "type": {
-                                        "type": "map",
-                                        "values": "string"
-                                      }
-                                    },
-                                    {
-                                      "name": "tenant_id",
-                                      "type": "string",
-                                      "default": ""
-                                    }
-                                  ]
-                                
-                                }
-      --pulsar.topic="metrics"  The Pulsar topic to publish the metrics on
-      --log.level=info          Only log messages with the given severity or
-                                above. One of: [debug, info, warn, error]
-      --log.format=logfmt       Output format of log messages. One of: [logfmt,
-                                json]
+                                 Specifies the serialization format
+                                 
+                                 json: JSON default format as defined by
+                                 github.com/prometheus/common/model
+                                 
+                                 {
+                                 
+                                   "metric": {
+                                     "__name__": "foo",
+                                     "labelfoo": "label-bar"
+                                   },
+                                   "value": [
+                                     0,
+                                     "456"
+                                   ]
+                                 
+                                 }
+                                 
+                                 json-compat: JSON compat provides compatability
+                                 with
+                                 github.com/liangyuanpeng/prometheus-pulsar-adapter
+                                 
+                                 {
+                                 
+                                   "name": "foo",
+                                   "labels": {
+                                     "__name__": "foo",
+                                     "labelfoo": "label-bar"
+                                   },
+                                   "value": "456",
+                                   "timestamp": "1970-01-01T00:00:00Z"
+                                 
+                                 }
+                                 
+                                 avro-json-compat[=<path to schema>]: AVRO-JSON
+                                 which can optionally read a custom schema
+                                 
+                                 Default schema: {
+                                 
+                                   "namespace": "io.prometheus",
+                                   "type": "record",
+                                   "name": "Metric",
+                                   "doc:": "A basic schema for representing Prometheus metrics",
+                                   "fields": [
+                                     {
+                                       "name": "timestamp",
+                                       "type": "string"
+                                     },
+                                     {
+                                       "name": "value",
+                                       "type": "string"
+                                     },
+                                     {
+                                       "name": "name",
+                                       "type": "string"
+                                     },
+                                     {
+                                       "name": "labels",
+                                       "type": {
+                                         "type": "map",
+                                         "values": "string"
+                                       }
+                                     },
+                                     {
+                                       "name": "tenant_id",
+                                       "type": "string",
+                                       "default": ""
+                                     }
+                                   ]
+                                 
+                                 }
+      --pulsar.topic="metrics"   The Pulsar topic to publish the metrics on
+      --log.level=info           Only log messages with the given severity or
+                                 above. One of: [debug, info, warn, error]
+      --log.format=logfmt        Output format of log messages. One of: [logfmt,
+                                 json]
 ```
 
 ## Development


### PR DESCRIPTION
For de-duplicating messages from HA replicas, we need to ensure order of remote writes. To achieve that we are using the same partition key for metrics using the same labels (expect replica labels) and tenant-ids.

Fixes #3