### PR TITLE
Use a single shared producer

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -177,6 +177,7 @@ func (ti *testIntegration) test(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	writers, readers := buildClients(logger, cfg)
+	defer closeClients(logger, writers, readers)
 
 	server := &http.Server{
 		Addr: cfg.listenAddr,


### PR DESCRIPTION
This PR switches from creating and destroying a producer for every batch to a model where we share a single producer and reuse it while the adapter is running.

To clean-up opened resources we are handling signals now properly and first shutdown the HTTP server and then the Clients.
