### PR TITLE
Provides option to limit lifetime of HTTP connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [ENHANCEMENT] Add pprof endpoints by default and add parameter `--web.disable-pprof` to disable them. #23
+* [ENHANCEMENT] Add configuration parameter `--web.max-connection-age` to limit lifetime of HTTP connections. #22
 
 ## 0.1.1 / 2020-08-27
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Flags:
                                  Path under which to expose metrics.
       --web.disable-pprof        Disable the pprof tracing/debugging endpoints
                                  under /debug/pprof.
+      --web.max-connection-age=0s  
+                                 If set this limits the maximum lifetime of
+                                 persistent HTTP connections.
       --web.write-path="/write"  Path under which to receive remote_write
                                  requests.
       --replica-label=__replica__ ...  

--- a/context/context.go
+++ b/context/context.go
@@ -2,12 +2,14 @@ package context
 
 import (
 	"context"
+	"time"
 )
 
 type key uint8
 
 const (
 	tenantIDKey key = iota
+	connectionStartTimeKey
 )
 
 func TenantIDFromContext(ctx context.Context) string {
@@ -20,4 +22,16 @@ func TenantIDFromContext(ctx context.Context) string {
 
 func ContextWithTenantID(ctx context.Context, tenantID string) context.Context {
 	return context.WithValue(ctx, tenantIDKey, tenantID)
+}
+
+func ConnectionStartTimeFromContext(ctx context.Context) (t time.Time, ok bool) {
+	v := ctx.Value(connectionStartTimeKey)
+	if v == nil {
+		return time.Time{}, false
+	}
+	return *v.(*time.Time), true
+}
+
+func ContextWithConnectionStartTime(ctx context.Context, t time.Time) context.Context {
+	return context.WithValue(ctx, connectionStartTimeKey, &t)
 }

--- a/context/handlers_test.go
+++ b/context/handlers_test.go
@@ -1,0 +1,73 @@
+package context_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	mcontext "github.com/grafana/prometheus-pulsar-remote-write/context"
+)
+
+type fakeClock struct {
+	Time *time.Time
+}
+
+func (f *fakeClock) Now() time.Time {
+	return *f.Time
+}
+
+func TestMaxConnectionAgeHandler(t *testing.T) {
+	t1 := time.Unix(1577873472, 0)
+	t2 := t1.Add(500 * time.Millisecond)
+	t3 := t1.Add(1001 * time.Millisecond)
+	fclock := &fakeClock{Time: &t1}
+	mcontext.WithClock(fclock)
+
+	// set start time
+	ctx := mcontext.ContextWithConnectionStartTime(
+		context.Background(),
+		t1,
+	)
+
+	// test context getter
+	tFromContext, ok := mcontext.ConnectionStartTimeFromContext(ctx)
+	assert.Equal(t, t1, tFromContext)
+	assert.True(t, ok)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	h := mcontext.MaxConnectionAgeHandler(mux, time.Second)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// first request at the same time
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, "", rr.Header().Get("Connection"))
+
+	// advance time half a second
+	fclock.Time = &t2
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, "", rr.Header().Get("Connection"))
+
+	// advance time half a second and a bit
+	fclock.Time = &t3
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, "close", rr.Header().Get("Connection"))
+
+}


### PR DESCRIPTION
This can be optionally configured to ensure a better balancing, if this adapter is been run with multiple replicas.