### PR TITLE
Separate creation of client and producer

### DIFF
--- a/pkg/app/produce.go
+++ b/pkg/app/produce.go
@@ -78,7 +78,7 @@ func (p *produceCommand) pulsarClient() (*pulsar.Client, error) {
 		return nil, err
 	}
 
-	return client, nil
+	return client, client.InitProducer()
 }
 
 func (p *produceCommand) buildWriters() ([]writer, error) {


### PR DESCRIPTION
This allows to create a client and later decide if a producer or
consumer is needed.

Signed-off-by: Christian Simon <simon@swine.de>