### PR TITLE
Enable goimports and gofmt linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+---
+linters-settings:
+  goimports:
+    local-prefixes: github.com/grafana/prometheus-pulsar-remote-write
+linters:
+  enable:
+    - goimports
+    - gofmt


### PR DESCRIPTION
This enables checking for `goimports` order and if the `gofmt` simple syntax is used